### PR TITLE
map遍历数组bug

### DIFF
--- a/src/core/base.js
+++ b/src/core/base.js
@@ -227,7 +227,8 @@ var JPlus = (function (undefined) {
 
 			// 遍历对象。
 			Object.each(iterable, dest ? function (value, key, array) {
-			    this[value] = fn(value, key, array);
+			    //this[value] = fn(value, key, array); 无法对dest进行正确的赋值
+			    this[key] = fn(value, key, array);
 			} : fn, dest);
 
 			// 返回目标。


### PR DESCRIPTION
当map遍历数组时会错误的赋值为[a: "aa", b: "bb", c: "cc"]
